### PR TITLE
use pkg-config and shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,10 @@
 import PackageDescription
 
 let package = Package(
-    name: "RopeLibpq"
+    name: "RopeLibpq",
+    pkgConfig: "libpq",
+    providers: [
+        .Brew("postgresql"),
+        .Apt("libpq-dev")
+    ]
 )

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,11 +1,5 @@
-module RopeMacOS [system] {
-    header "/usr/local/include/libpq-fe.h"
-    link "pq"
-    export *
-}
-
-module RopeLinux [system] {
-    header "/usr/include/postgresql/libpq-fe.h"
+module RopeLibpq [system] {
+    header "shim.h"
     link "pq"
     export *
 }

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,6 @@
+#ifndef RopeLibpq_shim_h
+#define RopeLibpq_shim_h
+
+#include <libpq-fe.h>
+
+#endif


### PR DESCRIPTION
Hides OS hard coded path to find headers, and allow to just import RopeLibpq in Rope without any platform specific import.